### PR TITLE
Erro ao enviar NF que possuem caracteres especiais

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -726,5 +726,14 @@ class AccountInvoice(models.Model):
                 obj._onchange_date_maturity()
 
     @api.model
+    def line_get_convert(self, line, part):
+        ret = super(AccountInvoice, self).line_get_convert(line, part)
+
+        ret['title_type_id'] = line.get('title_type_id')
+        ret['financial_operation_id'] = line.get('financial_operation_id')
+
+        return ret
+
+    @api.model
     def _function_br_account(self):
         self.env.ref('account.action_account_payment_from_invoices').unlink()

--- a/br_account/models/account_move.py
+++ b/br_account/models/account_move.py
@@ -22,6 +22,7 @@ class AccountMove(models.Model):
         ('reversal_discount', 'Reversal Discount'),
         ('reversal_interest', 'Reversal Interest'),
         ('company_expense', 'Company Expense'),
+        ('employee_expense', 'Company Expense'),
         ('releases', 'Releases'),
     ]
 

--- a/br_account/views/account_invoice.xml
+++ b/br_account/views/account_invoice.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="invoice_tree" model="ir.ui.view">
+        <field name="name">br_account.invoice.tree</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_tree"/>
+        <field name="arch" type="xml">
+            <field name="date_due" position="after">
+                <field name="fiscal_position_id"/>
+            </field>
+            <field name="company_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
     <record id="view_br_account_invoice_form" model="ir.ui.view">
         <field name="name">br_account.invoice.form</field>
         <field name="model">account.invoice</field>

--- a/br_nfse_paulistana/models/invoice_electronic.py
+++ b/br_nfse_paulistana/models/invoice_electronic.py
@@ -266,7 +266,7 @@ class InvoiceElectronic(models.Model):
 
             values = {}
 
-            if retorno and retorno.Cabecalho.Sucesso:
+            if retorno.Cabecalho.Sucesso:
                 values.update({
                     'state': 'done',
                     'codigo_retorno': '100',


### PR DESCRIPTION
- [x] Erro ao enviar NFSe que possuia caracteres especiais (&, ` e etc)
- [x] Tipo de titulo e operação financeira não estavam sendo copiados para move lines