### PR TITLE
[IMP] Bloquear criação de parcelas manualmente e valor da parcela positivo

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2009 Renato Lima - Akretion
 # © 2016 Danimar Ribeiro, Trustcode
+# © 2017 Michell Stuttgart, MultidadosTI
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -590,7 +591,7 @@ class AccountInvoice(models.Model):
     def compare_total_parcel_value(self):
 
         # Obtemos o total dos valores da parcela
-        total = sum([p.parceling_value for p in self.parcel_ids])
+        total = sum([abs(p.parceling_value) for p in self.parcel_ids])
 
         # Obtemos a precisao configurada
         prec = self.env['decimal.precision'].precision_get('Account')

--- a/br_account/tests/test_br_account_invoice_parcel.py
+++ b/br_account/tests/test_br_account_invoice_parcel.py
@@ -75,6 +75,16 @@ class TestBrAccountInvoiceParcel(TransactionCase):
         # Verificamos a diferenca entre pre_invoice_date e old_date_maturity
         self.assertEqual(self.parcel.amount_days, 14)
 
+    def test_compute_abs_parceling_value(self):
+        self.parcel.parceling_value = -2
+
+        self.parcel.compute_abs_parceling_value()
+
+        # Verificamos se 'abs_parceling_value' esta com o valor positivo da
+        # parcela
+        self.assertEqual(self.parcel.abs_parceling_value,
+                         abs(self.parcel.parceling_value))
+
     def test_compute_amount_days(self):
 
         # Verificamos se o metodo calcula a quantidade correta de dias

--- a/br_account/views/account_invoice.xml
+++ b/br_account/views/account_invoice.xml
@@ -78,23 +78,7 @@
                             attrs="{'invisible': [('state', '!=', 'draft')]}"
                             string="Gerar Parcelas"/>
                     <separator/>
-                    <field nolabel="1" name="parcel_ids">
-                        <tree name="parcelas"
-                              string="Parcelas"
-                              delete="false"
-                              colors="red:date_maturity&lt;current_date"
-                              editable="bottom">
-                            <field name="invoice_id" invisible="1"/>
-                            <field name="company_currency_id" invisible="1"/>
-                            <field name="date_maturity"/>
-                            <field name="name"/>
-                            <field name="parceling_value" sum="Valor Total"/>
-                            <field name="financial_operation_id"/>
-                            <field name="title_type_id"/>
-                            <field name="pin_date"/>
-                            <field name="amount_days"/>
-                        </tree>
-                    </field>
+                    <field nolabel="1" name="parcel_ids"/>
                 </page>
             </page>
             <page name="other_info" position="after">

--- a/br_account/views/account_invoice.xml
+++ b/br_account/views/account_invoice.xml
@@ -31,14 +31,24 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_invoice_open']" position="before">
-                <button name="action_br_account_invoice_open" type="object" states="draft" string="Confirmar"
-                        class="oe_highlight" groups="account.group_account_invoice"/>
-                <button name="action_br_account_invoice_open" type="object" states="proforma2" string="Confirmar"
+                <button name="action_br_account_invoice_open"
+                        type="object"
+                        states="draft"
+                        string="Confirmar"
+                        class="oe_highlight"
+                        groups="account.group_account_invoice"/>
+
+                <button name="action_br_account_invoice_open"
+                        type="object"
+                        states="proforma2"
+                        string="Confirmar"
                         groups="account.group_account_invoice"/>
             </xpath>
             <field name="date_invoice" position="replace">
-                <field name="date_invoice" attrs="{'readonly': 1, 'invisible': [('state', '=', 'draft')]}"/>
-                <field name="pre_invoice_date" attrs="{'readonly':[('state','!=','draft')]}"/>
+                <field name="date_invoice"
+                       attrs="{'readonly': 1, 'invisible': [('state', '=', 'draft')]}"/>
+                <field name="pre_invoice_date"
+                       attrs="{'readonly':[('state','!=','draft')]}"/>
             </field>
             <field name="date_due" position="attributes">
                 <attribute name="invisible">1</attribute>
@@ -84,7 +94,8 @@
             <page name="other_info" position="after">
                 <page name="vencimentos" string="Títulos">
                     <field nolabel="1" name="receivable_move_line_ids">
-                        <tree name="vencimentos" string="Vencimentos"
+                        <tree name="vencimentos"
+                              string="Vencimentos"
                               colors="grey:reconciled==True;red:date_maturity&lt;current_date">
                             <field name="date_maturity"/>
                             <field name="name"/>
@@ -171,8 +182,11 @@
         <field name="inherit_id" ref="account_cancel.invoice_form_cancel_inherit"/>
         <field name="arch" type="xml">
             <button name="action_invoice_cancel" position="replace">
-                <button name="action_invoice_cancel_paid" type="object" states="draft,proforma2,open,paid"
-                        string="Cancelar Fatura" groups="account.group_account_invoice"/>
+                <button name="action_invoice_cancel_paid"
+                        type="object"
+                        states="draft,proforma2,open,paid"
+                        string="Cancelar Fatura"
+                        groups="account.group_account_invoice"/>
             </button>
         </field>
     </record>
@@ -190,7 +204,12 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_invoice_open']" position="before">
-                <button name="action_br_account_invoice_open" type="object" states="draft,proforma2" string="Validate" class="oe_highlight" groups="account.group_account_invoice"/>
+                <button name="action_br_account_invoice_open"
+                        type="object"
+                        states="draft,proforma2"
+                        string="Validate"
+                        class="oe_highlight"
+                        groups="account.group_account_invoice"/>
             </xpath>
             <field name="fiscal_position_id" position="replace"/>
             <field name="payment_term_id" position="replace"/>
@@ -283,8 +302,11 @@
         <field name="inherit_id" ref="account_cancel.invoice_supplier_cancel_form_inherit"/>
         <field name="arch" type="xml">
             <button name="action_invoice_cancel" position="replace">
-                <button name="action_invoice_cancel_paid" type="object" states="draft,proforma2,open,paid"
-                        string="Cancelar Fatura" groups="account.group_account_invoice"/>
+                <button name="action_invoice_cancel_paid"
+                        type="object"
+                        states="draft,proforma2,open,paid"
+                        string="Cancelar Fatura"
+                        groups="account.group_account_invoice"/>
             </button>
         </field>
     </record>

--- a/br_account/views/account_invoice.xml
+++ b/br_account/views/account_invoice.xml
@@ -233,19 +233,7 @@
                             attrs="{'invisible': ['|',('state', '!=', 'draft'),('payment_term_id', '=', False)]}"
                             string="Gerar Parcelas"/>
                     <separator/>
-                    <field nolabel="1" name="parcel_ids">
-                        <tree name="parcelas" string="Parcelas" colors="red:date_maturity&lt;current_date"
-                              editable="bottom">
-                            <field name="invoice_id" invisible="1"/>
-                            <field name="date_maturity"/>
-                            <field name="name"/>
-                            <field name="parceling_value"/>
-                            <field name="financial_operation_id"/>
-                            <field name="title_type_id"/>
-                            <field name="pin_date"/>
-                            <field name="amount_days"/>
-                        </tree>
-                    </field>
+                    <field nolabel="1" name="parcel_ids"/>
                 </page>
             </xpath>
 

--- a/br_account/views/br_account_invoice_parcel.xml
+++ b/br_account/views/br_account_invoice_parcel.xml
@@ -5,11 +5,16 @@
         <field name="name">br_account.invoice.parcel.tree.view</field>
         <field name="model">br_account.invoice.parcel</field>
         <field name="arch" type="xml">
-            <tree string="Parcelas">
+            <tree name="parcelas"
+                  string="Parcelas"
+                  delete="false"
+                  create="false"
+                  colors="red:date_maturity&lt;current_date"
+                  editable="bottom">
                 <field name="invoice_id" invisible="1"/>
                 <field name="company_currency_id" invisible="1"/>
-                <field name="date_maturity"/>
                 <field name="old_date_maturity" invisible="1"/>
+                <field name="date_maturity"/>
                 <field name="name"/>
                 <field name="parceling_value" sum="Valor Total"/>
                 <field name="financial_operation_id"/>

--- a/br_account/views/br_account_invoice_parcel.xml
+++ b/br_account/views/br_account_invoice_parcel.xml
@@ -16,7 +16,8 @@
                 <field name="old_date_maturity" invisible="1"/>
                 <field name="date_maturity"/>
                 <field name="name"/>
-                <field name="parceling_value" sum="Valor Total"/>
+                <field name="parceling_value" invisible="1"/>
+                <field name="abs_parceling_value" sum="Valor Total"/>
                 <field name="financial_operation_id"/>
                 <field name="title_type_id"/>
                 <field name="pin_date"/>
@@ -39,6 +40,7 @@
                         <field name="old_date_maturity" invisible="1"/>
                         <field name="name"/>
                         <field name="parceling_value"/>
+                        <field name="abs_parceling_value"/>
                         <field name="amount_currency" groups="base.group_multi_currency"/>
                         <field name="financial_operation_id"/>
                         <field name="title_type_id"/>


### PR DESCRIPTION
- [x] [FIX] Permite a criação de parcelas na fatura apenas pelo botão de gerar parcelas
- [x] [FIX] Adicionado campo para exibir valor absoluto das parcelas, já que as parcelas de fatura de fornecedor exibem valores negativos de parcela
- [x] [FIX] Método de verificação do valor total das parcelas com o valor total das faturas agora compara o valor absoluto das parcelas, para funcionar com fatura de fornecedor
